### PR TITLE
Increase max characters for names

### DIFF
--- a/frmGuild.frm
+++ b/frmGuild.frm
@@ -185,7 +185,7 @@ Begin VB.Form frmGuild
          EndProperty
          ForeColor       =   &H009AADC2&
          Height          =   255
-         Left            =   4320
+         Left            =   4800
          TabIndex        =   26
          Top             =   120
          Width           =   1335
@@ -246,7 +246,7 @@ Begin VB.Form frmGuild
          EndProperty
          ForeColor       =   &H009AADC2&
          Height          =   255
-         Left            =   3360
+         Left            =   3960
          TabIndex        =   23
          Top             =   120
          Width           =   735
@@ -330,7 +330,7 @@ Begin VB.Form frmGuild
          Left            =   840
          TabIndex        =   19
          Top             =   120
-         Width           =   2535
+         Width           =   2895
       End
       Begin VB.Label cptHall 
          BackColor       =   &H0061514B&

--- a/frmMagic.frm
+++ b/frmMagic.frm
@@ -142,7 +142,7 @@ Begin VB.Form frmMagic
       EndProperty
       Height          =   375
       Left            =   1320
-      MaxLength       =   15
+      MaxLength       =   25
       TabIndex        =   0
       Text            =   " "
       Top             =   600

--- a/frmMain.frm
+++ b/frmMain.frm
@@ -702,11 +702,12 @@ Begin VB.Form frmMain
          Begin VB.Label lblSellPrice 
             BackColor       =   &H0044342E&
             ForeColor       =   &H009AADC2&
-            Height          =   255
-            Left            =   720
+            Height          =   735
+            Left            =   650
             TabIndex        =   104
-            Top             =   1440
+            Top             =   1580
             Width           =   1695
+		    WordWrap        =   -1  'True
          End
          Begin VB.Label cptSellPrice 
             AutoSize        =   -1  'True
@@ -716,17 +717,18 @@ Begin VB.Form frmMain
             Height          =   195
             Left            =   120
             TabIndex        =   103
-            Top             =   1440
+            Top             =   1560
             Width           =   405
          End
          Begin VB.Label lblSellName 
             BackColor       =   &H0044342E&
             ForeColor       =   &H009AADC2&
-            Height          =   255
-            Left            =   720
+            Height          =   480
+            Left            =   645
             TabIndex        =   102
-            Top             =   1080
+            Top             =   975
             Width           =   1695
+		    WordWrap        =   -1  'True
          End
          Begin VB.Label cptSellName 
             AutoSize        =   -1  'True
@@ -736,7 +738,7 @@ Begin VB.Form frmMain
             Height          =   195
             Left            =   120
             TabIndex        =   101
-            Top             =   1080
+            Top             =   960
             Width           =   465
          End
       End
@@ -766,21 +768,23 @@ Begin VB.Form frmMain
       Begin VB.Label lblSellNPCTalk 
          BackColor       =   &H0044342E&
          ForeColor       =   &H009AADC2&
-         Height          =   2295
+         Height          =   2055
          Left            =   2760
          TabIndex        =   106
-         Top             =   480
+         Top             =   720
          Width           =   2175
+		 WordWrap        =   -1  'True
       End
       Begin VB.Label lblSellNPCName 
          Alignment       =   2  'Center
          BackColor       =   &H0044342E&
          ForeColor       =   &H009AADC2&
-         Height          =   255
+         Height          =   495
          Left            =   2760
          TabIndex        =   105
          Top             =   120
          Width           =   2175
+		 WordWrap		 =   -1  'True
       End
       Begin VB.Label lblMenu 
          Alignment       =   2  'Center

--- a/frmMonster.frm
+++ b/frmMonster.frm
@@ -246,10 +246,10 @@ Begin VB.Form frmMonster
       EndProperty
       Height          =   375
       Left            =   1200
-      MaxLength       =   15
+      MaxLength       =   35
       TabIndex        =   0
       Top             =   600
-      Width           =   2895
+      Width           =   4215
    End
    Begin VB.CommandButton btnCancel 
       Cancel          =   -1  'True
@@ -821,4 +821,10 @@ Private Sub sclStrength_Scroll()
     sclStrength_Change
 End Sub
 
-
+Private Sub cmbObject_Click(Index As Integer)
+    If Len(cmbObject(Index).Text) > 12 Then
+        cmbObject(Index).ToolTipText = cmbObject(Index).Text
+    Else
+        cmbObject(Index).ToolTipText = ""
+    End If
+End Sub

--- a/frmNPC.frm
+++ b/frmNPC.frm
@@ -245,7 +245,7 @@ Begin VB.Form frmNPC
       EndProperty
       Height          =   375
       Left            =   1320
-      MaxLength       =   15
+      MaxLength       =   35
       TabIndex        =   0
       Top             =   600
       Width           =   3855
@@ -565,4 +565,28 @@ Sub UpdateList()
         cmbTakeObject.AddItem CStr(A) + ": " + Object(A).name
     Next A
     lstSaleItems.ListIndex = 0
+End Sub
+
+Private Sub lstSaleItems_MouseMove(Button As Integer, Shift As Integer, X As Single, Y As Single)
+    Dim iIndex As Long
+    iIndex = GetCursorIndex(lstSaleItems.hWnd)
+    If Len(lstSaleItems.List(iIndex)) > 60 Then
+        lstSaleItems.ToolTipText = lstSaleItems.List(iIndex)
+    Else
+        lstSaleItems.ToolTipText = ""
+    End If
+End Sub
+Private Sub cmbGiveObject_Click()
+    If Len(cmbGiveObject.Text) > 12 Then
+        cmbGiveObject.ToolTipText = cmbGiveObject.Text
+    Else
+        cmbGiveObject.ToolTipText = ""
+    End If
+End Sub
+Private Sub cmbTakeObject_Click()
+    If Len(cmbTakeObject.Text) > 12 Then
+        cmbTakeObject.ToolTipText = cmbTakeObject.Text
+    Else
+        cmbTakeObject.ToolTipText = ""
+    End If
 End Sub

--- a/frmNewGuild.frm
+++ b/frmNewGuild.frm
@@ -19,11 +19,11 @@ Begin VB.Form frmNewGuild
       BackColor       =   &H0044342E&
       ForeColor       =   &H009AADC2&
       Height          =   375
-      Left            =   1440
-      MaxLength       =   15
+      Left            =   1200
+      MaxLength       =   25
       TabIndex        =   0
       Top             =   120
-      Width           =   3135
+      Width           =   3375
    End
    Begin VB.Label btnOk 
       Alignment       =   2  'Center

--- a/frmObject.frm
+++ b/frmObject.frm
@@ -123,7 +123,7 @@ Begin VB.Form frmObject
       EndProperty
       Height          =   375
       Left            =   1320
-      MaxLength       =   15
+      MaxLength       =   35
       TabIndex        =   20
       Top             =   600
       Width           =   3855

--- a/frmPrefix.frm
+++ b/frmPrefix.frm
@@ -39,7 +39,7 @@ Begin VB.Form frmPrefix
    Begin VB.TextBox txtName 
       Height          =   285
       Left            =   1680
-      MaxLength       =   15
+      MaxLength       =   20
       TabIndex        =   17
       Top             =   480
       Width           =   2295

--- a/frmSuffix.frm
+++ b/frmSuffix.frm
@@ -38,7 +38,7 @@ Begin VB.Form frmSuffix
    Begin VB.TextBox txtName 
       Height          =   285
       Left            =   1680
-      MaxLength       =   15
+      MaxLength       =   20
       TabIndex        =   17
       Top             =   480
       Width           =   2295

--- a/modAPI.bas
+++ b/modAPI.bas
@@ -1,6 +1,11 @@
 Attribute VB_Name = "modAPI"
 Option Explicit
 
+Public Type MouseLoc
+	X As Long
+	Y As Long
+End Type
+
 'Odyssey DLL functions
 Public Declare Function EncryptDataFile Lib "odysseydll" (ByRef File As Any, ByVal XorValue As Byte) As Long
 Public Declare Function EncryptDataString Lib "odysseydll" (ByRef File As Any, ByVal XorValue As Byte) As Long
@@ -38,9 +43,11 @@ Declare Function WaitForSingleObject Lib "kernel32" (ByVal hHandle As Long, ByVa
 Public Declare Function CallWindowProc Lib "user32" Alias "CallWindowProcA" (ByVal lpPrevWndFunc As Long, ByVal hwnd As Long, ByVal Msg As Long, ByVal wParam As Long, ByVal lParam As Long) As Long
 Public Declare Function SetWindowLong Lib "user32" Alias "SetWindowLongA" (ByVal hwnd As Long, ByVal nIndex As Long, ByVal dwNewLong As Long) As Long
 
-'SendMessage
+'Interface
 Public Declare Function SendMessage Lib "user32" Alias "SendMessageA" (ByVal hwnd As Long, ByVal wMsg As Long, ByVal wParam As Long, lParam As Any) As Long
 Public Declare Function ReleaseCapture Lib "user32" () As Long
+Public Declare Function GetCursorPos Lib "user32" (lpPoint As MouseLoc) As Long
+Public Declare Function ScreenToClient Lib "user32" (ByVal hWnd As Long, lpPoint As MouseLoc) As Long
 
 'FindWindow
 Public Declare Function GetParent Lib "user32.dll" (ByVal hwnd As Long) As Long
@@ -57,3 +64,12 @@ Public Declare Function IsWindowVisible Lib "user32" (ByVal hwnd As Long) As Lon
 Public Declare Function GetCurrentProcess Lib "kernel32" () As Long
 Public Declare Function SetPriorityClass Lib "kernel32" (ByVal hProcess As Long, ByVal dwPriorityClass As Long) As Long
 Public Declare Function GetPriorityClass Lib "kernel32" (ByVal hProcess As Long) As Long
+
+Public Function GetCursorIndex(ListHandle As Long) As Long
+    Dim Cursor As MouseLoc
+    Dim iIndex As Long
+    
+    Call GetCursorPos(Cursor)
+    Call ScreenToClient(ListHandle, Cursor)
+    GetCursorIndex = SendMessage(ListHandle, &H1A9, 0&, ByVal ((Cursor.X And &HFF) Or (&H10000 * (Cursor.Y And &HFF))))
+End Function

--- a/modCache.bas
+++ b/modCache.bas
@@ -2,38 +2,38 @@ Attribute VB_Name = "modCache"
 Option Explicit
 
 Sub LoadObject(TheObj As Integer)
-    Dim St As String * 27
-    Open CacheDirectory + "/ocache.dat" For Random As #1 Len = 27
+    Dim St As String * 47
+    Open CacheDirectory + "/ocache.dat" For Random As #1 Len = 47
     Get #1, TheObj, St
     Close #1
     With Object(TheObj)
-        .name = ClipString$(Mid$(St, 1, 15))
-        .Picture = Asc(Mid$(St, 16, 1)) * 256 + Asc(Mid$(St, 17, 1))
-        .Type = Asc(Mid$(St, 18, 1))
+        .name = ClipString$(Mid$(St, 1, 35))
+        .Picture = Asc(Mid$(St, 36, 1)) * 256 + Asc(Mid$(St, 37, 1))
+        .Type = Asc(Mid$(St, 38, 1))
         Select Case .Type
         Case 8    'Ring
-            .MaxDur = Asc(Mid$(St, 20, 1))
-            .Data2 = Asc(Mid$(St, 19, 1))
-            .Modifier = Asc(Mid$(St, 21, 1))
+            .MaxDur = Asc(Mid$(St, 40, 1))
+            .Data2 = Asc(Mid$(St, 39, 1))
+            .Modifier = Asc(Mid$(St, 41, 1))
         Case 10, 11    'Projectile Weapon
-            .Modifier = Asc(Mid$(St, 19, 1))
-            .Data2 = Asc(Mid$(St, 21, 1))
+            .Modifier = Asc(Mid$(St, 39, 1))
+            .Data2 = Asc(Mid$(St, 41, 1))
         Case Else
-            .MaxDur = Asc(Mid$(St, 19, 1))
-            .Modifier = Asc(Mid$(St, 20, 1))
-            .Data2 = Asc(Mid$(St, 21, 1))
+            .MaxDur = Asc(Mid$(St, 39, 1))
+            .Modifier = Asc(Mid$(St, 40, 1))
+            .Data2 = Asc(Mid$(St, 41, 1))
         End Select
-        .flags = Asc(Mid$(St, 22, 1))
-        .ClassReq = Asc(Mid$(St, 23, 1))
-        .LevelReq = Asc(Mid$(St, 24, 1))
-        .Version = Asc(Mid$(St, 25, 1))
-        .SellPrice = Asc(Mid$(St, 26, 1)) * 256 + Asc(Mid$(St, 27, 1))
+        .flags = Asc(Mid$(St, 42, 1))
+        .ClassReq = Asc(Mid$(St, 43, 1))
+        .LevelReq = Asc(Mid$(St, 44, 1))
+        .Version = Asc(Mid$(St, 45, 1))
+        .SellPrice = Asc(Mid$(St, 46, 1)) * 256 + Asc(Mid$(St, 47, 1))
     End With
 End Sub
 
 Sub SaveObject(TheObj As Long)
-    Dim St1 As String * 15
-    Dim WritableData As String * 27
+    Dim St1 As String * 35
+    Dim WritableData As String * 47
     With Object(TheObj)
         St1 = .name
         Select Case .Type
@@ -45,7 +45,7 @@ Sub SaveObject(TheObj As Long)
             WritableData = St1 + DoubleChar$(CLng(.Picture)) + Chr$(.Type) + Chr$(.MaxDur) + Chr$(.Modifier) + Chr$(.Data2) + Chr$(.flags) + Chr$(.ClassReq) + Chr$(.LevelReq) + Chr$(.Version) + DoubleChar$(CLng(.SellPrice))
         End Select
     End With
-    Open CacheDirectory + "/ocache.dat" For Random As #1 Len = 27
+    Open CacheDirectory + "/ocache.dat" For Random As #1 Len = 47
     Put #1, TheObj, WritableData
     Close #1
 End Sub
@@ -62,9 +62,9 @@ End Sub
 
 Sub CreateObjectCache()
     If Exists(CacheDirectory + "/ocache.dat") Then Kill CacheDirectory + "/ocache.dat"
-    Dim St1 As String * 27, A As Long
-    St1 = String$(27, 0)
-    Open CacheDirectory + "/ocache.dat" For Random As #1 Len = 27
+    Dim St1 As String * 47, A As Long
+    St1 = String$(47, 0)
+    Open CacheDirectory + "/ocache.dat" For Random As #1 Len = 47
     For A = 1 To MaxObjects
         Put #1, , St1
     Next A
@@ -73,9 +73,9 @@ End Sub
 
 Sub CreateNPCCache()
     If Exists(CacheDirectory + "/ncache.dat") Then Kill CacheDirectory + "/ncache.dat"
-    Dim St1 As String * 137, A As Long
-    St1 = String$(137, 0)
-    Open CacheDirectory + "/ncache.dat" For Random As #1 Len = 137
+    Dim St1 As String * 157, A As Long
+    St1 = String$(157, 0)
+    Open CacheDirectory + "/ncache.dat" For Random As #1 Len = 157
     For A = 1 To MaxNPCs
         Put #1, , St1
     Next A
@@ -95,9 +95,9 @@ End Sub
 
 Sub CreateMonsterCache()
     If Exists(CacheDirectory + "/moncache.dat") Then Kill CacheDirectory + "/moncache.dat"
-    Dim St1 As String * 21, A As Long
-    St1 = String$(21, 0)
-    Open CacheDirectory + "/moncache.dat" For Random As #1 Len = 21
+    Dim St1 As String * 41, A As Long
+    St1 = String$(41, 0)
+    Open CacheDirectory + "/moncache.dat" For Random As #1 Len = 41
     For A = 1 To MaxTotalMonsters
         Put #1, , St1
     Next A
@@ -106,9 +106,9 @@ End Sub
 
 Sub CreateMagicCache()
     If Exists(CacheDirectory + "/magcache.dat") Then Kill CacheDirectory + "/magcache.dat"
-    Dim St1 As String * 124, A As Long
-    St1 = String$(124, 0)
-    Open CacheDirectory + "/magcache.dat" For Random As #1 Len = 124
+    Dim St1 As String * 134, A As Long
+    St1 = String$(134, 0)
+    Open CacheDirectory + "/magcache.dat" For Random As #1 Len = 134
     For A = 1 To MaxMagic
         Put #1, , St1
     Next A
@@ -117,9 +117,9 @@ End Sub
 
 Sub CreatePrefixCache()
     If Exists(CacheDirectory + "/itemprecache.dat") Then Kill CacheDirectory + "/itemprecache.dat"
-    Dim St1 As String * 19, A As Long
-    St1 = String$(19, 0)
-    Open CacheDirectory + "/itemprecache.dat" For Random As #1 Len = 19
+    Dim St1 As String * 24, A As Long
+    St1 = String$(24, 0)
+    Open CacheDirectory + "/itemprecache.dat" For Random As #1 Len = 24
     For A = 1 To MaxModifications
         Put #1, , St1
     Next A
@@ -128,9 +128,9 @@ End Sub
 
 Sub CreateSuffixCache()
     If Exists(CacheDirectory + "/itemsufcache.dat") Then Kill CacheDirectory + "/itemsufcache.dat"
-    Dim St1 As String * 19, A As Long
-    St1 = String$(19, 0)
-    Open CacheDirectory + "/itemsufcache.dat" For Random As #1 Len = 19
+    Dim St1 As String * 24, A As Long
+    St1 = String$(24, 0)
+    Open CacheDirectory + "/itemsufcache.dat" For Random As #1 Len = 24
     For A = 1 To MaxModifications
         Put #1, , St1
     Next A
@@ -138,8 +138,8 @@ Sub CreateSuffixCache()
 End Sub
 
 Sub SaveNPC(TheNPC As Long)
-    Dim St1 As String * 15
-    Dim WritableData As String * 137
+    Dim St1 As String * 35
+    Dim WritableData As String * 157
     Dim OutputString As String
     Dim A As Long
 
@@ -152,7 +152,7 @@ Sub SaveNPC(TheNPC As Long)
         WritableData = St1 + Chr$(.Version) + Chr$(.flags) + OutputString
     End With
 
-    Open CacheDirectory + "/ncache.dat" For Random As #1 Len = 137
+    Open CacheDirectory + "/ncache.dat" For Random As #1 Len = 157
     Put #1, TheNPC, WritableData
     Close #1
 End Sub
@@ -170,29 +170,29 @@ Sub SaveHall(TheHall As Long)
 End Sub
 
 Sub SaveMonster(TheMonster As Long)
-    Dim St1 As String * 15
-    Dim WritableData As String * 21
+    Dim St1 As String * 35
+    Dim WritableData As String * 41
     With Monster(TheMonster)
         St1 = .name
         WritableData = St1 + DoubleChar$(CLng(.Sprite)) + Chr$(.Version) + DoubleChar$(CLng(.MaxLife)) + Chr$(.flags)
     End With
-    Open CacheDirectory + "/moncache.dat" For Random As #1 Len = 21
+    Open CacheDirectory + "/moncache.dat" For Random As #1 Len = 41
     Put #1, TheMonster, WritableData
     Close #1
 End Sub
 
 Sub LoadNPC(TheNPC As Integer)
-    Dim St As String * 137
+    Dim St As String * 157
     Dim A As Long, B As Long
-    Open CacheDirectory + "/ncache.dat" For Random As #1 Len = 137
+    Open CacheDirectory + "/ncache.dat" For Random As #1 Len = 157
     Get #1, TheNPC, St
     Close #1
     With NPC(TheNPC)
-        .name = ClipString$(Mid$(St, 1, 15))
-        .Version = Asc(Mid$(St, 16, 1))
-        .flags = Asc(Mid$(St, 17, 1))
+        .name = ClipString$(Mid$(St, 1, 35))
+        .Version = Asc(Mid$(St, 36, 1))
+        .flags = Asc(Mid$(St, 37, 1))
         For A = 0 To 9
-            B = 18 + A * 12
+            B = 38 + A * 12
             .SaleItem(A).GiveObject = Asc(Mid$(St, B, 1)) * 256& + Asc(Mid$(St, B + 1, 1))
             .SaleItem(A).GiveValue = Asc(Mid$(St, B + 2, 1)) * 16777216 + Asc(Mid$(St, B + 3, 1)) * 65536 + Asc(Mid$(St, B + 4, 1)) * 256& + Asc(Mid$(St, B + 5, 1))
             .SaleItem(A).TakeObject = Asc(Mid$(St, B + 6, 1)) * 256& + Asc(Mid$(St, B + 7, 1))
@@ -213,100 +213,100 @@ Sub LoadHall(TheHall As Integer)
 End Sub
 
 Sub LoadMonster(TheMonster As Integer)
-    Dim St As String * 21
-    Open CacheDirectory + "/moncache.dat" For Random As #1 Len = 21
+    Dim St As String * 41
+    Open CacheDirectory + "/moncache.dat" For Random As #1 Len = 41
     Get #1, TheMonster, St
     Close #1
     With Monster(TheMonster)
-        .name = ClipString$(Mid$(St, 1, 15))
-        .Sprite = Asc(Mid$(St, 16, 1)) * 256 + Asc(Mid$(St, 17, 1))
-        .Version = Asc(Mid$(St, 18, 1))
-        .MaxLife = GetInt(Mid$(St, 19, 2))
-        .flags = Asc(Mid$(St, 21, 1))
+        .name = ClipString$(Mid$(St, 1, 35))
+        .Sprite = Asc(Mid$(St, 36, 1)) * 256 + Asc(Mid$(St, 37, 1))
+        .Version = Asc(Mid$(St, 38, 1))
+        .MaxLife = GetInt(Mid$(St, 39, 2))
+        .flags = Asc(Mid$(St, 41, 1))
     End With
 End Sub
 
 Sub LoadMagic(TheMagic As Integer)
-    Dim St As String * 124
-    Open CacheDirectory + "/magcache.dat" For Random As #1 Len = 124
+    Dim St As String * 134
+    Open CacheDirectory + "/magcache.dat" For Random As #1 Len = 134
     Get #1, TheMagic, St
     Close #1
     With Magic(TheMagic)
-        .name = ClipString$(Mid$(St, 1, 15))
-        .Version = Asc(Mid$(St, 16, 1))
+        .name = ClipString$(Mid$(St, 1, 25))
+        .Version = Asc(Mid$(St, 26, 1))
         If .Version > 0 Then
-            .Level = Asc(Mid$(St, 17, 1))
-            .Class = Asc(Mid$(St, 18, 1))
-            .Icon = Asc(Mid$(St, 19, 1)) * 256 + Asc(Mid$(St, 20, 1))
-            .IconType = Asc(Mid$(St, 21, 1))
-            .CastTimer = Asc(Mid$(St, 22, 1)) * 256 + Asc(Mid$(St, 23, 1))
-            .Description = ClipString$(Mid$(St, 24, 100))
+            .Level = Asc(Mid$(St, 27, 1))
+            .Class = Asc(Mid$(St, 28, 1))
+            .Icon = Asc(Mid$(St, 29, 1)) * 256 + Asc(Mid$(St, 30, 1))
+            .IconType = Asc(Mid$(St, 31, 1))
+            .CastTimer = Asc(Mid$(St, 32, 1)) * 256 + Asc(Mid$(St, 33, 1))
+            .Description = ClipString$(Mid$(St, 34, 100))
         End If
     End With
 End Sub
 
 Sub SaveMagic(TheMagic As Integer)
-    Dim St1 As String * 15
+    Dim St1 As String * 25
     Dim St2 As String * 100
-    Dim WritableData As String * 124
+    Dim WritableData As String * 134
     With Magic(TheMagic)
         St1 = .name
         St2 = .Description
         WritableData = St1 + Chr$(.Version) + Chr$(.Level) + Chr$(.Class) + DoubleChar$(CLng(.Icon)) + Chr$(.IconType) + DoubleChar$(CLng(.CastTimer)) + St2
     End With
-    Open CacheDirectory + "/magcache.dat" For Random As #1 Len = 124
+    Open CacheDirectory + "/magcache.dat" For Random As #1 Len = 134
     Put #1, TheMagic, WritableData
     Close #1
 End Sub
 
 Sub LoadPrefix(ThePrefix As Integer)
-    Dim St As String * 19
-    Open CacheDirectory + "/itemprecache.dat" For Random As #1 Len = 19
+    Dim St As String * 24
+    Open CacheDirectory + "/itemprecache.dat" For Random As #1 Len = 24
     Get #1, ThePrefix, St
     Close #1
     With ItemPrefix(ThePrefix)
-        .name = ClipString$(Mid$(St, 1, 15))
-        .Version = Asc(Mid$(St, 16, 1))
-        .ModificationType = Asc(Mid$(St, 17, 1))
-        .ModificationValue = Asc(Mid$(St, 18, 1))
-        .OccursNaturally = Asc(Mid$(St, 19, 1))
+        .name = ClipString$(Mid$(St, 1, 20))
+        .Version = Asc(Mid$(St, 21, 1))
+        .ModificationType = Asc(Mid$(St, 22, 1))
+        .ModificationValue = Asc(Mid$(St, 23, 1))
+        .OccursNaturally = Asc(Mid$(St, 24, 1))
     End With
 End Sub
 
 Sub LoadSuffix(TheSuffix As Integer)
-    Dim St As String * 19
-    Open CacheDirectory + "/itemsufcache.dat" For Random As #1 Len = 19
+    Dim St As String * 24
+    Open CacheDirectory + "/itemsufcache.dat" For Random As #1 Len = 24
     Get #1, TheSuffix, St
     Close #1
     With ItemSuffix(TheSuffix)
-        .name = ClipString$(Mid$(St, 1, 15))
-        .Version = Asc(Mid$(St, 16, 1))
-        .ModificationType = Asc(Mid$(St, 17, 1))
-        .ModificationValue = Asc(Mid$(St, 18, 1))
-        .OccursNaturally = Asc(Mid$(St, 19, 1))
+        .name = ClipString$(Mid$(St, 1, 20))
+        .Version = Asc(Mid$(St, 21, 1))
+        .ModificationType = Asc(Mid$(St, 22, 1))
+        .ModificationValue = Asc(Mid$(St, 23, 1))
+        .OccursNaturally = Asc(Mid$(St, 24, 1))
     End With
 End Sub
 
 Sub SavePrefix(ThePrefix As Byte)
-    Dim St1 As String * 15
-    Dim WritableData As String * 19
+    Dim St1 As String * 20
+    Dim WritableData As String * 24
     With ItemPrefix(ThePrefix)
         St1 = .name
         WritableData = St1 + Chr$(.Version) + Chr$(.ModificationType) + Chr$(.ModificationValue) + Chr$(.OccursNaturally)
     End With
-    Open CacheDirectory + "/itemprecache.dat" For Random As #1 Len = 19
+    Open CacheDirectory + "/itemprecache.dat" For Random As #1 Len = 24
     Put #1, ThePrefix, WritableData
     Close #1
 End Sub
 
 Sub SaveSuffix(TheSuffix As Byte)
-    Dim St1 As String * 15
-    Dim WritableData As String * 19
+    Dim St1 As String * 20
+    Dim WritableData As String * 24
     With ItemSuffix(TheSuffix)
         St1 = .name
         WritableData = St1 + Chr$(.Version) + Chr$(.ModificationType) + Chr$(.ModificationValue) + Chr$(.OccursNaturally)
     End With
-    Open CacheDirectory + "/itemsufcache.dat" For Random As #1 Len = 19
+    Open CacheDirectory + "/itemsufcache.dat" For Random As #1 Len = 24
     Put #1, TheSuffix, WritableData
     Close #1
 End Sub
@@ -329,7 +329,7 @@ Sub CheckCache()
         frmWait.Refresh
         CreateObjectCache
     Else
-        If FileLen(CacheDirectory + "/ocache.dat") <> 27000 Then
+        If FileLen(CacheDirectory + "/ocache.dat") <> 47000 Then
             frmWait.lblStatus = "Creating Object Cache .."
             frmWait.Refresh
             CreateObjectCache
@@ -353,7 +353,7 @@ Sub CheckCache()
         frmWait.Refresh
         CreateNPCCache
     Else
-        If FileLen(CacheDirectory + "/ncache.dat") <> 68500 Then
+        If FileLen(CacheDirectory + "/ncache.dat") <> 78500 Then
             frmWait.lblStatus = "Creating NPC Cache .."
             frmWait.Refresh
             CreateNPCCache
@@ -365,7 +365,7 @@ Sub CheckCache()
         frmWait.Refresh
         CreateMonsterCache
     Else
-        If FileLen(CacheDirectory + "/moncache.dat") <> 21000 Then
+        If FileLen(CacheDirectory + "/moncache.dat") <> 41000 Then
             frmWait.lblStatus = "Creating Monster Cache .."
             frmWait.Refresh
             CreateMonsterCache
@@ -377,7 +377,7 @@ Sub CheckCache()
         frmWait.Refresh
         CreateMagicCache
     Else
-        If FileLen(CacheDirectory + "/magcache.dat") <> 62000 Then
+        If FileLen(CacheDirectory + "/magcache.dat") <> 67000 Then
             frmWait.lblStatus = "Creating Magic Cache .."
             frmWait.Refresh
             CreateMagicCache
@@ -389,7 +389,7 @@ Sub CheckCache()
         frmWait.Refresh
         CreatePrefixCache
     Else
-        If FileLen(CacheDirectory + "/itemprecache.dat") <> 4845 Then
+        If FileLen(CacheDirectory + "/itemprecache.dat") <> 6120 Then
             frmWait.lblStatus = "Creating Prefix Cache .."
             frmWait.Refresh
             CreatePrefixCache
@@ -401,7 +401,7 @@ Sub CheckCache()
         frmWait.Refresh
         CreateSuffixCache
     Else
-        If FileLen(CacheDirectory + "/itemsufcache.dat") <> 4845 Then
+        If FileLen(CacheDirectory + "/itemsufcache.dat") <> 6120 Then
             frmWait.lblStatus = "Creating Suffix Cache .."
             frmWait.Refresh
             CreateSuffixCache

--- a/modInterface.bas
+++ b/modInterface.bas
@@ -124,7 +124,7 @@ Private Sub RealDrawCurInvObject()
         If CurInvObj <= 20 Then
             If Character.Inv(CurInvObj).Object > 0 Then
                 DrawToDC 0, 0, 32, 32, frmMain.picObject.hDC, DDSObjects, 0, (Object(Character.Inv(CurInvObj).Object).Picture - 1) * 32
-                frmMain.lblCurObj = Object(Character.Inv(CurInvObj).Object).name
+                'frmMain.lblCurObj = Object(Character.Inv(CurInvObj).Object).name
 
                 'First line (the name line)
                 If Character.Inv(CurInvObj).ItemPrefix > 0 Then
@@ -254,7 +254,7 @@ Private Sub RealDrawCurInvObject()
         Else
             TheObj = CurInvObj - 20
             If Character.EquippedObject(TheObj).Object > 0 Then
-                frmMain.lblCurObj = Object(Character.EquippedObject(TheObj).Object).name
+                'frmMain.lblCurObj = Object(Character.EquippedObject(TheObj).Object).name
                 DrawToDC 0, 0, 32, 32, frmMain.picObject.hDC, DDSObjects, 0, (Object(Character.EquippedObject(TheObj).Object).Picture - 1) * 32
                 If Character.EquippedObject(TheObj).ItemPrefix > 0 Then
                     If Len(ItemPrefix(Character.EquippedObject(TheObj).ItemPrefix).name) > 0 Then


### PR DESCRIPTION
Item/Monster/NPC Names increased to 35 characters
Guild/Magic Names increased to 25 characters
Prefix/Suffix Names increased to 20 characters

Edits to some window graphics to allow for longer display names.

Removed Object names from displaying to lblCurObj in modInterface
The name was being displayed twice anyway, and lblCurObj display width is fixed to 25 characters by the interface background (interface.rsc)